### PR TITLE
feat: add CLI data file option

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/app/core/config_collector.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/app/core/config_collector.py
@@ -91,10 +91,14 @@ def collect_cli_config() -> Optional[PipelineState]:
         return None
 
 
-def collect_interactive_config() -> PipelineState:
+def collect_interactive_config(data_file_override: Optional[str] = None) -> PipelineState:
     """
-    Collect configuration through interactive prompts
-    
+    Collect configuration through interactive prompts.
+
+    Args:
+        data_file_override: Optional path to a data file supplied via CLI.
+                            When provided, file selection prompts are skipped.
+
     Returns:
         PipelineState with user-provided configuration
     """
@@ -124,39 +128,42 @@ def collect_interactive_config() -> PipelineState:
     
     # Data file (optional)
     print("\n4. Data Configuration:")
-    data_file_path = None
+    data_file_path = data_file_override
     synthetic_bars = 5000
-    
-    use_file = input("Use data file? (y/N): ").strip().lower()
-    if use_file in ['y', 'yes']:
-        # Try to use tkinter file dialog
-        try:
-            import tkinter as tk
-            from tkinter import filedialog
-            print("Opening file dialog...")
-            root = tk.Tk()
-            root.withdraw()
-            root.attributes('-topmost', True)  # Bring to front on Windows
-            data_file_path = filedialog.askopenfilename(
-                title="Select Data File",
-                filetypes=[
-                    ("Trading Data", ("*.csv", "*.parquet", "*.CSV", "*.PARQUET")),
-                    ("CSV files", ("*.csv", "*.CSV")),
-                    ("Parquet files", ("*.parquet", "*.PARQUET")),
-                    ("All files", "*.*")
-                ]
-            )
-            root.destroy()
-            if not data_file_path:
-                print("No file selected, will use synthetic data")
-            else:
-                print(f"Selected file: {data_file_path}")
-        except (ImportError, Exception) as e:
-            print(f"File dialog failed ({e}), enter file path manually:")
-            data_file_path = input("Enter data file path (or press Enter for synthetic): ").strip()
-            if not data_file_path:
-                data_file_path = None
-    
+
+    if data_file_path:
+        print(f"Using data file provided via CLI: {data_file_path}")
+    else:
+        use_file = input("Use data file? (y/N): ").strip().lower()
+        if use_file in ['y', 'yes']:
+            # Try to use tkinter file dialog
+            try:
+                import tkinter as tk
+                from tkinter import filedialog
+                print("Opening file dialog...")
+                root = tk.Tk()
+                root.withdraw()
+                root.attributes('-topmost', True)  # Bring to front on Windows
+                data_file_path = filedialog.askopenfilename(
+                    title="Select Data File",
+                    filetypes=[
+                        ("Trading Data", ("*.csv", "*.parquet", "*.CSV", "*.PARQUET")),
+                        ("CSV files", ("*.csv", "*.CSV")),
+                        ("Parquet files", ("*.parquet", "*.PARQUET")),
+                        ("All files", "*.*")
+                    ]
+                )
+                root.destroy()
+                if not data_file_path:
+                    print("No file selected, will use synthetic data")
+                else:
+                    print(f"Selected file: {data_file_path}")
+            except (ImportError, Exception) as e:
+                print(f"File dialog failed ({e}), enter file path manually:")
+                data_file_path = input("Enter data file path (or press Enter for synthetic): ").strip()
+                if not data_file_path:
+                    data_file_path = None
+
     # Ask for synthetic data amount if not using file
     if not data_file_path:
         bars_input = input("Enter number of synthetic bars to generate (default: 5000): ").strip()

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/__init__.py
@@ -17,8 +17,9 @@ from .data_loader import (
     # Main data loading classes
     DataLoader,
     InteractiveDataLoader,
-    
+
     # Utility functions
+    load_data_file,
     load_data_from_file,
     create_synthetic_data
 )

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/data_loader.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/data_loader.py
@@ -81,12 +81,21 @@ class DataLoader:
             raise
 
 
+def load_data_file(file_path: str) -> pd.DataFrame:
+    """Load data from a file path without any interactive prompts."""
+    loader = DataLoader()
+    return loader.load_file(file_path)
+
+
+# Backwards compatibility alias
+def load_data_from_file(file_path: str) -> pd.DataFrame:
+    """Compatibility wrapper for load_data_file."""
+    return load_data_file(file_path)
+
+
 class InteractiveDataLoader:
     """Interactive data loader with GUI file picker"""
-    
-    def __init__(self):
-        self.loader = DataLoader()
-    
+
     def load_data_interactive(self) -> Optional[pd.DataFrame]:
         """
         Interactive data loading with GUI file picker
@@ -169,7 +178,7 @@ class InteractiveDataLoader:
             
             if file_path:
                 print(f"Selected: {file_path}")
-                return self.loader.load_file(file_path)
+                return load_data_file(file_path)
             else:
                 print("No file selected")
                 return None
@@ -219,7 +228,7 @@ class InteractiveDataLoader:
             if 1 <= choice <= len(found_files):
                 selected_file = found_files[choice - 1]
                 print(f"Loading: {selected_file}")
-                return self.loader.load_file(str(selected_file))
+                return load_data_file(str(selected_file))
             elif choice == len(found_files) + 1:
                 return self._manual_file_input()
             else:
@@ -253,7 +262,7 @@ class InteractiveDataLoader:
                 continue
             
             try:
-                return self.loader.load_file(file_path)
+                return load_data_file(file_path)
             except Exception as e:
                 print(f"Error loading file: {e}")
                 continue
@@ -277,22 +286,6 @@ class InteractiveDataLoader:
         except ValueError:
             print("Invalid input, using defaults")
             return create_synthetic_data()
-
-
-def load_data_from_file(file_path: str) -> pd.DataFrame:
-    """
-    Convenience function to load data from file
-    
-    Args:
-        file_path: Path to data file
-        
-    Returns:
-        DataFrame with loaded data
-    """
-    loader = DataLoader()
-    return loader.load_file(file_path)
-
-
 def interactive_data_setup() -> pd.DataFrame:
     """
     Convenience function for interactive data loading

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/main_runner.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/main_runner.py
@@ -10,6 +10,7 @@ Database management is handled by the optimization module through its
 existing StorageConfig system in optimization/config/optuna_config.py.
 """
 
+import argparse
 import logging
 import sys
 
@@ -22,13 +23,22 @@ def main():
     """Main entry point - detect mode and orchestrate pipeline"""
 
     try:
+        # Extract optional data file argument without triggering CLI mode
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument('--data-file')
+        args, remaining = parser.parse_known_args()
+        data_file = args.data_file
+        sys.argv = [sys.argv[0]] + remaining
+
         # Collect configuration based on mode
         if is_cli_mode():
+            if data_file:
+                sys.argv.extend(['--data-file', data_file])
             state = collect_cli_config()
             if state is None:
                 return 1  # CLI parsing failed or --help
         else:
-            state = collect_interactive_config()
+            state = collect_interactive_config(data_file_override=data_file)
 
         # Orchestrate the pipeline - optimization module handles PostgreSQL internally
         result = orchestrate_pipeline(state)


### PR DESCRIPTION
## Summary
- factor out a reusable `load_data_file` helper for path-based data loading
- allow supplying a data file via `--data-file` on the main runner to skip interactive prompts
- update interactive config collection to honor a CLI-provided data path

## Testing
- `python -m py_compile main_runner.py data/data_loader.py data/__init__.py app/core/config_collector.py`
- `python main_runner.py --data-file /tmp/dummy.csv` (manual entry aborted after confirmation message)


------
https://chatgpt.com/codex/tasks/task_e_68af6dfca0f483309753abf4e81ecef7