### PR TITLE
Vectorized stop-loss management with Numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 numpy
+numba
 optuna
 psycopg2-binary
 scikit-learn


### PR DESCRIPTION
## Summary
- Speed up Bollinger Squeeze position management using a Numba-compiled loop with low/high stop-loss checks
- Log JIT-based execution path and captured entry/exit events
- Add numba dependency

## Testing
- `python -m py_compile 'TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/strategies/bollinger_squeeze/strategy.py'`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7588b9488330b18742f621ce6fdc