### PR TITLE
Add unit tests for utilities and optimization flow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import pathlib
+
+# Ensure the core project package is importable despite spaces in path
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY"
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,54 @@
+import pytest
+from utils.error_handling import (
+    ErrorResultFactory,
+    log_and_return_error,
+    safe_execute,
+    validate_required_keys,
+    ensure_error_result_format,
+)
+
+
+def test_create_error_result_with_context_and_data():
+    result = ErrorResultFactory.create_error_result(
+        "failure", error_context="phase", additional_data={"extra": 1}
+    )
+    assert result["success"] is False
+    assert result["error"] == "failure"
+    assert result["error_context"] == "phase"
+    assert result["extra"] == 1
+    assert "timestamp" in result
+
+
+def test_log_and_return_error():
+    result = log_and_return_error("problem", context="ctx")
+    assert not result["success"]
+    assert result["error"] == "problem"
+    assert result["error_context"] == "ctx"
+
+
+def test_safe_execute_success_and_failure():
+    def good(x):
+        return x * 2
+
+    def bad():
+        raise ValueError("boom")
+
+    res_good = safe_execute(good, 3)
+    assert res_good["success"] and res_good["result"] == 6
+
+    res_bad = safe_execute(bad)
+    assert not res_bad["success"]
+    assert "error" in res_bad
+
+
+def test_validate_required_keys():
+    data = {"a": 1, "b": 2}
+    assert validate_required_keys(data, ["a", "b"], "ctx") is None
+    assert "missing" in validate_required_keys(data, ["a", "c"], "ctx")
+
+
+def test_ensure_error_result_format_adds_defaults():
+    result = ensure_error_result_format({"error": "oops"})
+    assert not result["success"]
+    assert "best_parameters" in result
+    assert "optimization_metadata" in result

--- a/tests/test_objective_factory.py
+++ b/tests/test_objective_factory.py
@@ -1,0 +1,68 @@
+import sys
+import types
+import pandas as pd
+import pytest
+
+# Stub torch and psutil before importing optimization modules
+torch_stub = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False, set_device=lambda x: None))
+psutil_stub = types.SimpleNamespace(
+    virtual_memory=lambda: types.SimpleNamespace(total=0),
+    Process=lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=0)),
+)
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("psutil", psutil_stub)
+
+from optimization.objective import ObjectiveFactory
+from optimization.config.optuna_config import OptimizationConfig
+from app.core.pipeline_orchestrator import AuthorizedDataAccess
+
+
+class DummyStrategy:
+    strategy_name = "dummy"
+
+    def get_parameter_ranges(self):
+        return {"x": (0, 1)}
+
+    def validate_parameters(self, params):
+        return True
+
+
+class EmptyRangeStrategy(DummyStrategy):
+    def get_parameter_ranges(self):
+        return {}
+
+
+class DummyTradingConfig:
+    account_config = None
+
+
+def make_access(train=None, validation=None):
+    df = pd.DataFrame({"x": [1]})
+    return AuthorizedDataAccess(train_data=train or df, validation_data=validation or df)
+
+
+def test_create_objective_requires_authorized_accesses():
+    strategy = DummyStrategy()
+    factory = ObjectiveFactory(OptimizationConfig())
+    with pytest.raises(ValueError) as exc:
+        factory.create_objective(strategy, [], DummyTradingConfig(), {})
+    assert "No authorized data accesses" in str(exc.value)
+
+
+def test_create_objective_requires_parameter_ranges():
+    strategy = EmptyRangeStrategy()
+    factory = ObjectiveFactory(OptimizationConfig())
+    access = make_access()
+    with pytest.raises(ValueError) as exc:
+        factory.create_objective(strategy, [access], DummyTradingConfig(), {})
+    assert "Strategy provided empty parameter ranges" in str(exc.value)
+
+
+def test_stateful_objective_validates_access_data():
+    strategy = DummyStrategy()
+    factory = ObjectiveFactory(OptimizationConfig())
+    empty_df = pd.DataFrame()
+    access = AuthorizedDataAccess(train_data=pd.DataFrame({"x": [1]}), validation_data=empty_df)
+    with pytest.raises(ValueError) as exc:
+        factory.create_objective(strategy, [access], DummyTradingConfig(), {})
+    assert "missing train or validation data" in str(exc.value)

--- a/tests/test_optuna_engine_flow.py
+++ b/tests/test_optuna_engine_flow.py
@@ -1,0 +1,105 @@
+import sys
+import types
+import pandas as pd
+import pytest
+
+# Provide minimal torch and psutil stubs before importing modules that require them
+torch_stub = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False, set_device=lambda x: None))
+psutil_stub = types.SimpleNamespace(
+    virtual_memory=lambda: types.SimpleNamespace(total=0),
+    Process=lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=0)),
+)
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("psutil", psutil_stub)
+
+from optimization.engine import OptunaEngine
+from app.core.state import PipelineState
+
+
+class DummyStrategy:
+    strategy_name = "dummy"
+
+    def get_parameter_ranges(self):
+        return {"x": (0, 1)}
+
+    def validate_parameters(self, params):
+        return True
+
+
+class DummyTradingConfig:
+    account_config = None
+
+
+def build_state(**kwargs):
+    defaults = dict(
+        strategy_name="s",
+        symbol="SYM",
+        timeframe="1m",
+        account_type="demo",
+        slippage_ticks=0,
+        commission_per_trade=0.0,
+        contracts_per_trade=1,
+        split_type="chronological",
+    )
+    defaults.update(kwargs)
+    return PipelineState(**defaults)
+
+
+def test_validate_pipeline_state_missing_strategy():
+    engine = OptunaEngine()
+    state = build_state(
+        trading_config=DummyTradingConfig(),
+        full_data=pd.DataFrame({"a": [1]}),
+        strategy_instance=None,
+    )
+    result = engine._validate_pipeline_state(state)
+    assert not result["valid"]
+    assert "No strategy instance" in result["error"]
+
+
+def test_run_returns_error_for_invalid_state():
+    engine = OptunaEngine()
+    state = build_state(
+        trading_config=DummyTradingConfig(),
+        full_data=pd.DataFrame({"a": [1]}),
+        strategy_instance=None,
+    )
+    output = engine.run(state)
+    assert not output["success"]
+    assert "Pipeline validation failed" in output["error"]
+
+
+def test_run_requires_secure_orchestrator():
+    engine = OptunaEngine()
+    strategy = DummyStrategy()
+    state = build_state(
+        trading_config=DummyTradingConfig(),
+        full_data=pd.DataFrame({"a": [1]}),
+        strategy_instance=strategy,
+    )
+    result = engine.run(state)
+    assert not result["success"]
+    assert "No secure orchestrator" in result["error"]
+
+
+def test_run_success_flow(monkeypatch):
+    engine = OptunaEngine()
+    strategy = DummyStrategy()
+    state = build_state(
+        trading_config=DummyTradingConfig(),
+        full_data=pd.DataFrame({"a": [1]}),
+        strategy_instance=strategy,
+        secure_orchestrator=True,
+    )
+
+    monkeypatch.setattr(engine, "_validate_pipeline_state", lambda s: {"valid": True})
+    monkeypatch.setattr(engine, "_prepare_optimization_data", lambda s: {"success": True, "authorized_accesses": []})
+    dummy_study = type("Study", (), {"trials": []})()
+    monkeypatch.setattr(engine, "_create_optuna_study", lambda s: {"success": True, "study": dummy_study, "paths": {}})
+    monkeypatch.setattr(engine.objective_factory, "create_objective", lambda *a, **k: lambda trial: 0)
+    monkeypatch.setattr(engine, "_run_optimization", lambda obj, st: {"success": True})
+    expected = {"success": True, "data": 1}
+    monkeypatch.setattr(engine, "_process_optimization_results", lambda s, p: expected)
+
+    output = engine.run(state)
+    assert output == expected

--- a/tests/test_price_seed_resolver.py
+++ b/tests/test_price_seed_resolver.py
@@ -1,0 +1,26 @@
+from utils.price_seed_resolver import PriceSeedResolver, DEFAULT_BASE_PRICE
+
+
+def test_resolve_uses_user_override():
+    resolver = PriceSeedResolver()
+    seed = resolver.resolve("ES", user_override=12345.0)
+    assert seed.base_price == 12345.0
+
+
+def test_resolve_uses_market_spec_price():
+    resolver = PriceSeedResolver()
+    seed = resolver.resolve("ES")
+    assert seed.base_price == 6340.0
+
+
+def test_resolve_unknown_symbol_defaults():
+    resolver = PriceSeedResolver()
+    seed = resolver.resolve("UNKNOWN")
+    assert seed.base_price == DEFAULT_BASE_PRICE
+
+
+def test_get_supported_symbols_sorted_and_contains():
+    resolver = PriceSeedResolver()
+    supported = resolver.get_supported_symbols()
+    assert supported == sorted(supported)
+    assert "ES" in supported and "NQ" in supported

--- a/tests/test_timezone_utils.py
+++ b/tests/test_timezone_utils.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+from utils import timezone_utils as tz
+
+
+def test_convert_to_target_timezone_naive_series():
+    series = pd.Series(pd.date_range("2024-01-01", periods=2, freq="H"))
+    converted = tz.convert_to_target_timezone(series)
+    assert str(converted.dt.tz) == tz.TARGET_TIMEZONE
+
+
+def test_convert_datetime_index_to_column():
+    index = pd.date_range("2024-01-01", periods=2, freq="H", tz="UTC")
+    df = pd.DataFrame({"value": [1, 2]}, index=index)
+    result = tz.convert_datetime_index_to_column(df)
+    assert "datetime" in result.columns
+    assert str(result["datetime"].dt.tz) == tz.TARGET_TIMEZONE
+
+
+def test_ensure_datetime_column_creates_from_candidates():
+    df = pd.DataFrame({"timestamp": ["2024-01-01 00:00", "2024-01-01 01:00"]})
+    result = tz.ensure_datetime_column(df)
+    assert "datetime" in result.columns
+    assert str(result["datetime"].dt.tz) == tz.TARGET_TIMEZONE
+
+
+def test_validate_datetime_column_success():
+    df = pd.DataFrame({"datetime": pd.date_range("2024-01-01", periods=1, tz=tz.TARGET_TIMEZONE)})
+    assert tz.validate_datetime_column(df)
+
+
+def test_validate_datetime_column_missing_raises():
+    df = pd.DataFrame()
+    with pytest.raises(ValueError):
+        tz.validate_datetime_column(df)


### PR DESCRIPTION
## Summary
- add tests for timezone normalization helpers
- add tests for price seed resolution logic
- add tests for error-handling utilities
- add tests verifying OptunaEngine validation, secure orchestrator requirement, and successful runs
- add tests ensuring ObjectiveFactory validates authorized data and parameter ranges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afc161a4308330b24a9a6e0e485fd6