### PR TITLE
Fix target price logging and deployment template path

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/deployment/deployment_engine.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/deployment/deployment_engine.py
@@ -154,11 +154,11 @@ class DeploymentEngine:
     def _find_deployment_template(self, strategy_name: str) -> Dict[str, Any]:
         """Find the deployment template for the given strategy."""
         
-        # Standard template path pattern
+        base_path = Path(__file__).resolve().parent.parent
         template_paths = [
-            Path(f"strategies/{strategy_name}/deployment_template.py"),
-            Path(f"strategies/{strategy_name.lower()}/deployment_template.py"),
-            Path(f"strategies/{strategy_name}/template.py"),
+            base_path / f"strategies/{strategy_name}/deployment_template.py",
+            base_path / f"strategies/{strategy_name.lower()}/deployment_template.py",
+            base_path / f"strategies/{strategy_name}/template.py",
         ]
         
         for template_path in template_paths:

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/strategies/bollinger_squeeze/strategy.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/strategies/bollinger_squeeze/strategy.py
@@ -254,8 +254,23 @@ class BollingerSqueezeStrategy(BaseStrategy):
                         bars_in_trade = 0
                         bars_since_exit = 0
                         entry_type = "long" if position == 1 else "short"
+                        entry_price_val = (
+                            entry_price.item()
+                            if hasattr(entry_price, "item")
+                            else entry_price
+                        )
+                        stop_loss_val = (
+                            stop_loss.item()
+                            if hasattr(stop_loss, "item")
+                            else stop_loss
+                        )
+                        target_price_val = (
+                            target_price.item()
+                            if hasattr(target_price, "item")
+                            else target_price
+                        )
                         self._debug_logger.debug(
-                            f"Bar {i}: {entry_type} entry at open price {entry_price.item()}, stop: {stop_loss.item()}, target: {target_price.item()}"
+                            f"Bar {i}: {entry_type} entry at open price {entry_price_val}, stop: {stop_loss_val}, target: {target_price_val}"
                         )
 
             final_signals[i] = position


### PR DESCRIPTION
## Summary
- avoid `.item()` calls on floats when logging entries in Bollinger Squeeze strategy
- resolve deployment template paths relative to project root to ensure deployment runs

## Testing
- `PYTHONPATH="TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY" pytest tests/test_objective_factory.py tests/test_optuna_engine_flow.py tests/test_optuna_engine_validation.py -q`
- `PYTHONPATH="TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY" python "TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/main_runner.py" --strategy bollinger_squeeze --symbol ES --timeframe 5m --account-type topstep_50k --slippage 0.25 --commission 2.5 --contracts-per-trade 1 --split-type chronological --synthetic-bars 5000 --max-trials 3 --max-workers 1`

------
https://chatgpt.com/codex/tasks/task_e_68afd892860c8330865b66d0b84a77b1