### PR TITLE
feat: expand validation module with statistical robustness tests

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/__init__.py
@@ -1,10 +1,44 @@
+"""Validation engine providing multiple statistical tests.
+
+This module implements a configurable validation engine capable of running
+several robustness tests over a collection of strategy parameter sets.  Each
+test returns a metric and a pass/fail flag and contributes to an aggregated
+score used by downstream analytics.
+
+The implementation is intentionally lightweight but mirrors the structure of
+an institutional pipeline.  Tests operate on in-sample and out-of-sample
+return series which are supplied in each parameter dictionary under the keys
+``in_sample_returns`` and ``out_of_sample_returns``.  If these keys are absent
+the numeric values in the parameter dictionary are used as a stand‑in.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+import os
+from typing import Any, Dict, Iterable, List, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclasses
 
 
 @dataclass
 class ValidationTestConfig:
-    """Configuration for a single validation test."""
+    """Configuration for a single validation test.
+
+    Attributes
+    ----------
+    enabled:
+        Whether this test should run.
+    params:
+        Optional parameters understood by the individual test implementation.
+        Thresholds for pass/fail decisions are also supplied here under the
+        ``threshold`` key when applicable.
+    """
 
     enabled: bool = True
     params: Dict[str, Any] = field(default_factory=dict)
@@ -17,54 +51,152 @@ class ValidationConfig:
     in_sample: ValidationTestConfig = field(default_factory=ValidationTestConfig)
     out_of_sample: ValidationTestConfig = field(default_factory=ValidationTestConfig)
     in_sample_permutation: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"permutations": 1000, "threshold": 0.05})
     )
     out_of_sample_permutation: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"permutations": 1000, "threshold": 0.05})
     )
     noise_injection: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"simulations": 100, "sigma": 0.01})
     )
     monte_carlo: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"simulations": 100})
     )
     regime_testing: ValidationTestConfig = field(
         default_factory=lambda: ValidationTestConfig(enabled=False)
     )
 
 
+# ---------------------------------------------------------------------------
+# Validation engine implementation
+
+
 class ValidationEngine:
     """Run configured validation tests over parameter sets.
 
-    The current implementation is lightweight and deterministic. Each enabled
-    test simply contributes to a list of executed tests, while the score is a
-    sum of numeric parameter values. The structure allows future replacement
-    with realistic validation logic operating on walk-forward data splits.
+    Parameters
+    ----------
+    config:
+        :class:`ValidationConfig` specifying which tests to run and their
+        parameters.
+    max_workers:
+        Maximum number of worker threads to use when evaluating strategies.
     """
 
-    def __init__(self, config: ValidationConfig | None = None) -> None:
+    def __init__(self, config: ValidationConfig | None = None, max_workers: int | None = None) -> None:
         self.config = config or ValidationConfig()
+        self.max_workers = max_workers or min(32, os.cpu_count() or 1)
 
-    def run(self, parameter_sets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Validate parameter sets and return scored results.
+    # -- helpers ---------------------------------------------------------
 
-        Args:
-            parameter_sets: List of parameter dictionaries.
+    @staticmethod
+    def _extract_returns(params: Dict[str, Any], key: str) -> np.ndarray:
+        data = params.get(key)
+        if data is None:
+            data = [v for v in params.values() if isinstance(v, (int, float))]
+        return np.asarray(list(data), dtype=float)
 
-        Returns:
-            List of validation result dictionaries containing the original
-            parameters, a deterministic score, and the list of executed tests.
-        """
+    @staticmethod
+    def _permutation_metric(data: np.ndarray, permutations: int, rng: np.random.Generator) -> Tuple[float, float]:
+        baseline = float(np.mean(data)) if data.size else 0.0
+        count = 0
+        for _ in range(permutations):
+            if np.mean(rng.permutation(data)) >= baseline:
+                count += 1
+        p_value = (count + 1) / (permutations + 1)
+        metric = 1.0 - p_value
+        return metric, p_value
 
-        results: List[Dict[str, Any]] = []
-        for params in parameter_sets:
-            score = sum(
-                value for value in params.values() if isinstance(value, (int, float))
-            )
-            executed = [
-                name
-                for name, cfg in self.config.__dict__.items()
-                if isinstance(cfg, ValidationTestConfig) and cfg.enabled
-            ]
-            results.append({"params": params, "score": score, "tests": executed})
-        return results
+    # -- individual tests ------------------------------------------------
+
+    def _test_in_sample(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        returns = self._extract_returns(params, "in_sample_returns")
+        metric = float(np.mean(returns)) if returns.size else 0.0
+        return metric, metric >= threshold
+
+    def _test_out_of_sample(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        returns = self._extract_returns(params, "out_of_sample_returns")
+        metric = float(np.mean(returns)) if returns.size else 0.0
+        return metric, metric >= threshold
+
+    def _test_in_sample_permutation(self, params: Dict[str, Any], *, permutations: int = 1000, threshold: float = 0.05, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metric, p_value = self._permutation_metric(data, permutations, rng)
+        return metric, p_value <= threshold
+
+    def _test_out_of_sample_permutation(self, params: Dict[str, Any], *, permutations: int = 1000, threshold: float = 0.05, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "out_of_sample_returns")
+        metric, p_value = self._permutation_metric(data, permutations, rng)
+        return metric, p_value <= threshold
+
+    def _test_noise_injection(self, params: Dict[str, Any], *, simulations: int = 100, sigma: float = 0.01, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metrics = []
+        for _ in range(simulations):
+            noisy = data + rng.normal(0, sigma, size=data.size)
+            metrics.append(float(np.mean(noisy)) if noisy.size else 0.0)
+        metric = float(np.percentile(metrics, 5)) if metrics else 0.0
+        return metric, metric >= threshold
+
+    def _test_monte_carlo(self, params: Dict[str, Any], *, simulations: int = 100, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metrics = []
+        for _ in range(simulations):
+            sample = rng.choice(data, size=data.size, replace=True) if data.size else np.array([])
+            metrics.append(float(np.mean(sample)) if sample.size else 0.0)
+        metric = float(np.percentile(metrics, 5)) if metrics else 0.0
+        return metric, metric >= threshold
+
+    def _test_regime_testing(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        if data.size < 2:
+            metric = float(np.mean(data)) if data.size else 0.0
+            return metric, metric >= threshold
+        mid = data.size // 2
+        regime1 = float(np.mean(data[:mid])) if mid else 0.0
+        regime2 = float(np.mean(data[mid:])) if data.size - mid else 0.0
+        metric = min(regime1, regime2)
+        return metric, metric >= threshold
+
+    # -- execution -------------------------------------------------------
+
+    def _run_single(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        # Derive a deterministic seed from the parameter set for reproducibility
+        seed = int(abs(hash(str(sorted(params.items())))) % (2**32))
+        rng = np.random.default_rng(seed)
+
+        results: Dict[str, Dict[str, Any]] = {}
+        executed: List[str] = []
+        total_score = 0.0
+        passed_all = True
+
+        for name, cfg in self.config.__dict__.items():
+            if not isinstance(cfg, ValidationTestConfig) or not cfg.enabled:
+                continue
+
+            test_fn = getattr(self, f"_test_{name}")
+            metric, passed = test_fn(params, rng=rng, **cfg.params)
+            results[name] = {"metric": metric, "passed": passed}
+            executed.append(name)
+            total_score += metric
+            passed_all = passed_all and passed
+
+        return {
+            "params": params,
+            "score": total_score,
+            "tests": executed,
+            "results": results,
+            "passed": passed_all,
+        }
+
+    def run(self, parameter_sets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Validate parameter sets and return scored results."""
+
+        params_list = list(parameter_sets)
+        workers = min(self.max_workers, len(params_list)) or 1
+        with ThreadPoolExecutor(max_workers=workers) as exe:
+            return list(exe.map(self._run_single, params_list))
+
+
+__all__ = ["ValidationConfig", "ValidationEngine", "ValidationTestConfig"]
+

--- a/tests/test_validation_analytics_packaging.py
+++ b/tests/test_validation_analytics_packaging.py
@@ -4,17 +4,26 @@ from packager import PackagingEngine
 
 
 def test_validation_analytics_packaging_flow():
-    params = [{"a": 1, "b": 2}, {"a": 0, "b": 0}]
+    params = [
+        {
+            "in_sample_returns": [0.6, 0.7, 0.8],
+            "out_of_sample_returns": [0.3, 0.2, 0.4],
+        },
+        {
+            "in_sample_returns": [0.0, 0.1, -0.1],
+            "out_of_sample_returns": [0.0, -0.2, 0.1],
+        },
+    ]
 
     val_engine = ValidationEngine()
     val_results = val_engine.run(params)
-    assert val_results[0]["score"] == 3
     assert "in_sample" in val_results[0]["tests"]
+    assert val_results[0]["score"] > val_results[1]["score"]
 
     analytics = AnalyticsEngine(max_size=1)
     analytics.ingest(val_results)
     winners = analytics.get_winners()
-    assert winners[0]["params"] == {"a": 1, "b": 2}
+    assert winners[0]["params"] == params[0]
 
     pkg_engine = PackagingEngine()
     pkg_result = pkg_engine.package("strat", winners)

--- a/tests/test_validation_engine.py
+++ b/tests/test_validation_engine.py
@@ -1,0 +1,51 @@
+import pytest
+
+from validation import ValidationEngine, ValidationConfig, ValidationTestConfig
+
+
+def test_validation_engine_runs_all_tests():
+    config = ValidationConfig(
+        in_sample=ValidationTestConfig(params={"threshold": 0.5}),
+        out_of_sample=ValidationTestConfig(params={"threshold": 0.2}),
+        in_sample_permutation=ValidationTestConfig(
+            enabled=True, params={"permutations": 10, "threshold": 1.0}
+        ),
+        out_of_sample_permutation=ValidationTestConfig(
+            enabled=True, params={"permutations": 10, "threshold": 1.0}
+        ),
+        noise_injection=ValidationTestConfig(
+            enabled=True, params={"simulations": 10, "sigma": 0.01}
+        ),
+        monte_carlo=ValidationTestConfig(
+            enabled=True, params={"simulations": 10}
+        ),
+        regime_testing=ValidationTestConfig(enabled=True),
+    )
+
+    engine = ValidationEngine(config=config, max_workers=1)
+    params = [
+        {
+            "in_sample_returns": [0.6, 0.7, 0.8],
+            "out_of_sample_returns": [0.3, 0.4, 0.5],
+        }
+    ]
+
+    results = engine.run(params)
+    assert len(results) == 1
+    res = results[0]
+    expected_tests = {
+        "in_sample",
+        "out_of_sample",
+        "in_sample_permutation",
+        "out_of_sample_permutation",
+        "noise_injection",
+        "monte_carlo",
+        "regime_testing",
+    }
+    assert set(res["tests"]) == expected_tests
+    assert set(res["results"].keys()) == expected_tests
+    assert res["passed"] is True
+    # Score is sum of individual metrics
+    metric_sum = sum(v["metric"] for v in res["results"].values())
+    assert res["score"] == pytest.approx(metric_sum)
+


### PR DESCRIPTION
## Summary
- implement configurable validation engine supporting in/out of sample, permutation, Monte Carlo, noise injection and regime tests
- run strategies in parallel and aggregate per-test metrics with pass/fail outcomes
- add comprehensive unit tests for validation engine and update flow test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afee4787c883309b61994a37a933e9