### PR TITLE
Use validation and test splits without optimization data

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/__init__.py
@@ -379,11 +379,11 @@ print(f"Full summary: {data_split.summary()}")
 
 3-WAY SPLIT BENEFITS:
 ====================
-NEW (3-way): optimize_data, validate_data, test_data
+The system uses explicit ``train``, ``validation`` and ``test`` segments.
 
-- optimize_data: Used for parameter tuning during optimization
-- validate_data: Used for evaluation during optimization (out-of-sample)
-- test_data: Reserved for final validation (never seen during optimization)
+- ``train``: Used for parameter tuning during optimization
+- ``validation``: Used for evaluation during optimization (out-of-sample)
+- ``test``: Reserved for final validation (never seen during optimization)
 
 This eliminates data leakage by ensuring optimization never sees test data.
 """

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/data_structures.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/data/data_structures.py
@@ -26,7 +26,7 @@ class DataSplit:
     separate datasets for training, validation, and testing.
     
     Fields:
-        train: DataFrame used for parameter tuning and model fitting (institutional terminology)
+        train: DataFrame used for parameter tuning and model fitting
         validation: DataFrame used for performance evaluation during optimization
         test: DataFrame reserved for final validation (unused during optimization)
         metadata: Dictionary containing split information and timestamps
@@ -249,31 +249,31 @@ if __name__ == "__main__":
     # Create test data with temporal ordering
     base_date = datetime(2020, 1, 1)
     
-    # Optimize data: Jan-Jun 2020
-    optimize_dates = pd.date_range(base_date, base_date + timedelta(days=180), freq='1h')
-    optimize_data = pd.DataFrame({
-        'datetime': optimize_dates,
-        'open': np.random.randn(len(optimize_dates)).cumsum() + 100,
-        'high': np.random.randn(len(optimize_dates)).cumsum() + 102,
-        'low': np.random.randn(len(optimize_dates)).cumsum() + 98,
-        'close': np.random.randn(len(optimize_dates)).cumsum() + 101,
-        'volume': np.random.randint(1000, 10000, len(optimize_dates))
+    # Train data: Jan-Jun 2020
+    train_dates = pd.date_range(base_date, base_date + timedelta(days=180), freq='1h')
+    train_data = pd.DataFrame({
+        'datetime': train_dates,
+        'open': np.random.randn(len(train_dates)).cumsum() + 100,
+        'high': np.random.randn(len(train_dates)).cumsum() + 102,
+        'low': np.random.randn(len(train_dates)).cumsum() + 98,
+        'close': np.random.randn(len(train_dates)).cumsum() + 101,
+        'volume': np.random.randint(1000, 10000, len(train_dates))
     })
-    
-    # Validate data: Jul-Sep 2020 (with 1-day gap)
-    validate_start = base_date + timedelta(days=181)
-    validate_dates = pd.date_range(validate_start, validate_start + timedelta(days=90), freq='1h')
-    validate_data = pd.DataFrame({
-        'datetime': validate_dates,
-        'open': np.random.randn(len(validate_dates)).cumsum() + 100,
-        'high': np.random.randn(len(validate_dates)).cumsum() + 102,
-        'low': np.random.randn(len(validate_dates)).cumsum() + 98,
-        'close': np.random.randn(len(validate_dates)).cumsum() + 101,
-        'volume': np.random.randint(1000, 10000, len(validate_dates))
+
+    # Validation data: Jul-Sep 2020 (with 1-day gap)
+    validation_start = base_date + timedelta(days=181)
+    validation_dates = pd.date_range(validation_start, validation_start + timedelta(days=90), freq='1h')
+    validation_data = pd.DataFrame({
+        'datetime': validation_dates,
+        'open': np.random.randn(len(validation_dates)).cumsum() + 100,
+        'high': np.random.randn(len(validation_dates)).cumsum() + 102,
+        'low': np.random.randn(len(validation_dates)).cumsum() + 98,
+        'close': np.random.randn(len(validation_dates)).cumsum() + 101,
+        'volume': np.random.randint(1000, 10000, len(validation_dates))
     })
-    
+
     # Test data: Oct-Dec 2020 (with 1-day gap)
-    test_start = validate_start + timedelta(days=91)
+    test_start = validation_start + timedelta(days=91)
     test_dates = pd.date_range(test_start, test_start + timedelta(days=90), freq='1h')
     test_data = pd.DataFrame({
         'datetime': test_dates,
@@ -295,8 +295,8 @@ if __name__ == "__main__":
     # Test DataSplit creation
     try:
         data_split = DataSplit(
-            train=optimize_data,
-            validation=validate_data,
+            train=train_data,
+            validation=validation_data,
             test=test_data,
             metadata=metadata
         )

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/__init__.py
@@ -1,10 +1,49 @@
+"""Validation engine providing multiple statistical tests.
+
+This module implements a configurable validation engine capable of running
+several robustness tests over a collection of strategy parameter sets.  Each
+test returns a metric and a pass/fail flag and contributes to an aggregated
+score used by downstream analytics.
+
+The implementation is intentionally lightweight but mirrors the structure of
+an institutional pipeline.  Tests operate on in-sample and out-of-sample
+return series which must be supplied in each parameter dictionary under the
+keys ``in_sample_returns`` and ``out_of_sample_returns`` or derived from an
+attached :class:`~data.data_structures.DataSplit`.  When a split is provided,
+the validation segment supplies in-sample returns while the test segment
+provides out-of-sample returns, keeping validation independent from earlier
+optimization steps.  Missing return series raise an error to preserve data
+lineage.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+import os
+import time
+from typing import Any, Dict, Iterable, List, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclasses
 
 
 @dataclass
 class ValidationTestConfig:
-    """Configuration for a single validation test."""
+    """Configuration for a single validation test.
+
+    Attributes
+    ----------
+    enabled:
+        Whether this test should run.
+    params:
+        Optional parameters understood by the individual test implementation.
+        Thresholds for pass/fail decisions are also supplied here under the
+        ``threshold`` key when applicable.
+    """
 
     enabled: bool = True
     params: Dict[str, Any] = field(default_factory=dict)
@@ -17,54 +56,190 @@ class ValidationConfig:
     in_sample: ValidationTestConfig = field(default_factory=ValidationTestConfig)
     out_of_sample: ValidationTestConfig = field(default_factory=ValidationTestConfig)
     in_sample_permutation: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"permutations": 1000, "threshold": 0.05})
     )
     out_of_sample_permutation: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"permutations": 1000, "threshold": 0.05})
     )
     noise_injection: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"simulations": 100, "sigma": 0.01})
     )
     monte_carlo: ValidationTestConfig = field(
-        default_factory=lambda: ValidationTestConfig(enabled=False)
+        default_factory=lambda: ValidationTestConfig(enabled=False, params={"simulations": 100})
     )
     regime_testing: ValidationTestConfig = field(
         default_factory=lambda: ValidationTestConfig(enabled=False)
     )
 
 
+# ---------------------------------------------------------------------------
+# Validation engine implementation
+
+
 class ValidationEngine:
     """Run configured validation tests over parameter sets.
 
-    The current implementation is lightweight and deterministic. Each enabled
-    test simply contributes to a list of executed tests, while the score is a
-    sum of numeric parameter values. The structure allows future replacement
-    with realistic validation logic operating on walk-forward data splits.
+    Parameters
+    ----------
+    config:
+        :class:`ValidationConfig` specifying which tests to run and their
+        parameters.
+    max_workers:
+        Maximum number of worker threads to use when evaluating strategies.
     """
 
-    def __init__(self, config: ValidationConfig | None = None) -> None:
+    def __init__(self, config: ValidationConfig | None = None, max_workers: int | None = None) -> None:
         self.config = config or ValidationConfig()
+        self.max_workers = max_workers or min(32, os.cpu_count() or 1)
 
-    def run(self, parameter_sets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Validate parameter sets and return scored results.
+    # -- helpers ---------------------------------------------------------
 
-        Args:
-            parameter_sets: List of parameter dictionaries.
+    @staticmethod
+    def _extract_returns(params: Dict[str, Any], key: str) -> np.ndarray:
+        """Extract a return series from ``params``.
 
-        Returns:
-            List of validation result dictionaries containing the original
-            parameters, a deterministic score, and the list of executed tests.
+        Returns are required for all validation tests and must be supplied
+        either via explicit ``in_sample_returns``/``out_of_sample_returns``
+        entries or derived from a provided :class:`DataSplit`.  Fallbacks to
+        numeric parameter values are no longer permitted as they could break
+        the pipeline's data lineage guarantees.
         """
 
-        results: List[Dict[str, Any]] = []
-        for params in parameter_sets:
-            score = sum(
-                value for value in params.values() if isinstance(value, (int, float))
+        data = params.get(key)
+        if data is None:
+            raise KeyError(f"Missing required returns series: {key}")
+        return np.asarray(list(data), dtype=float)
+
+    @staticmethod
+    def _permutation_metric(data: np.ndarray, permutations: int, rng: np.random.Generator) -> Tuple[float, float]:
+        baseline = float(np.mean(data)) if data.size else 0.0
+        count = 0
+        for _ in range(permutations):
+            if np.mean(rng.permutation(data)) >= baseline:
+                count += 1
+        p_value = (count + 1) / (permutations + 1)
+        metric = 1.0 - p_value
+        return metric, p_value
+
+    # -- individual tests ------------------------------------------------
+
+    def _test_in_sample(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        returns = self._extract_returns(params, "in_sample_returns")
+        metric = float(np.mean(returns)) if returns.size else 0.0
+        return metric, metric >= threshold
+
+    def _test_out_of_sample(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        returns = self._extract_returns(params, "out_of_sample_returns")
+        metric = float(np.mean(returns)) if returns.size else 0.0
+        return metric, metric >= threshold
+
+    def _test_in_sample_permutation(self, params: Dict[str, Any], *, permutations: int = 1000, threshold: float = 0.05, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metric, p_value = self._permutation_metric(data, permutations, rng)
+        return metric, p_value <= threshold
+
+    def _test_out_of_sample_permutation(self, params: Dict[str, Any], *, permutations: int = 1000, threshold: float = 0.05, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "out_of_sample_returns")
+        metric, p_value = self._permutation_metric(data, permutations, rng)
+        return metric, p_value <= threshold
+
+    def _test_noise_injection(self, params: Dict[str, Any], *, simulations: int = 100, sigma: float = 0.01, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metrics = []
+        for _ in range(simulations):
+            noisy = data + rng.normal(0, sigma, size=data.size)
+            metrics.append(float(np.mean(noisy)) if noisy.size else 0.0)
+        metric = float(np.percentile(metrics, 5)) if metrics else 0.0
+        return metric, metric >= threshold
+
+    def _test_monte_carlo(self, params: Dict[str, Any], *, simulations: int = 100, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        metrics = []
+        for _ in range(simulations):
+            sample = rng.choice(data, size=data.size, replace=True) if data.size else np.array([])
+            metrics.append(float(np.mean(sample)) if sample.size else 0.0)
+        metric = float(np.percentile(metrics, 5)) if metrics else 0.0
+        return metric, metric >= threshold
+
+    def _test_regime_testing(self, params: Dict[str, Any], *, threshold: float = 0.0, rng: np.random.Generator) -> Tuple[float, bool]:
+        data = self._extract_returns(params, "in_sample_returns")
+        if data.size < 2:
+            metric = float(np.mean(data)) if data.size else 0.0
+            return metric, metric >= threshold
+        mid = data.size // 2
+        regime1 = float(np.mean(data[:mid])) if mid else 0.0
+        regime2 = float(np.mean(data[mid:])) if data.size - mid else 0.0
+        metric = min(regime1, regime2)
+        return metric, metric >= threshold
+
+    # -- execution -------------------------------------------------------
+
+    def _run_single(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        # Parameter sets must contain a DataSplit so validation operates on the
+        # same data used during earlier pipeline stages. Any pre‑supplied
+        # return series are ignored in favour of the DataSplit contents to
+        # maintain data lineage guarantees.
+        params = dict(params)  # shallow copy so we can safely mutate
+        data_split = params.get("data_split")
+        if data_split is None:
+            raise ValueError(
+                "Parameter set must include 'data_split' with train/validation/test data"
             )
-            executed = [
-                name
-                for name, cfg in self.config.__dict__.items()
-                if isinstance(cfg, ValidationTestConfig) and cfg.enabled
-            ]
-            results.append({"params": params, "score": score, "tests": executed})
-        return results
+
+        def _as_returns(obj: Any) -> np.ndarray:
+            series = (
+                obj["returns"]
+                if hasattr(obj, "__getitem__") and "returns" in getattr(obj, "columns", [])
+                else obj
+            )
+            return np.asarray(series, dtype=float)
+
+        # Validation operates independently of optimization results.  Only the
+        # validation segment is considered in-sample while the boxed-off test
+        # split provides out-of-sample returns.
+        params["in_sample_returns"] = _as_returns(data_split.validation)
+        params["out_of_sample_returns"] = _as_returns(data_split.test)
+
+        # Derive a deterministic seed from the parameter set for reproducibility
+        seed = int(abs(hash(str(sorted(params.items())))) % (2**32))
+        rng = np.random.default_rng(seed)
+
+        start_time = time.perf_counter()
+        results: Dict[str, Dict[str, Any]] = {}
+        executed: List[str] = []
+        total_score = 0.0
+        passed_all = True
+
+        for name, cfg in self.config.__dict__.items():
+            if not isinstance(cfg, ValidationTestConfig) or not cfg.enabled:
+                continue
+
+            test_fn = getattr(self, f"_test_{name}")
+            metric, passed = test_fn(params, rng=rng, **cfg.params)
+            results[name] = {"metric": metric, "passed": passed}
+            executed.append(name)
+            total_score += metric
+            passed_all = passed_all and passed
+
+        runtime = time.perf_counter() - start_time
+
+        return {
+            "params": params,
+            "score": total_score,
+            "tests": executed,
+            "results": results,
+            "passed": passed_all,
+            "runtime": runtime,
+        }
+
+    def run(self, parameter_sets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Validate parameter sets and return scored results."""
+
+        params_list = list(parameter_sets)
+        workers = min(self.max_workers, len(params_list)) or 1
+        with ThreadPoolExecutor(max_workers=workers) as exe:
+            return list(exe.map(self._run_single, params_list))
+
+
+__all__ = ["ValidationConfig", "ValidationEngine", "ValidationTestConfig"]
+

--- a/tests/test_validation_analytics_packaging.py
+++ b/tests/test_validation_analytics_packaging.py
@@ -1,20 +1,36 @@
 from validation import ValidationEngine
 from analytics import AnalyticsEngine
 from packager import PackagingEngine
+import pandas as pd
+import pytest
+from data.data_structures import DataSplit
+
+
+def _split(optimize, validate, test):
+    return DataSplit(
+        train=pd.DataFrame({"returns": optimize}),
+        validation=pd.DataFrame({"returns": validate}),
+        test=pd.DataFrame({"returns": test}),
+        metadata={},
+    )
 
 
 def test_validation_analytics_packaging_flow():
-    params = [{"a": 1, "b": 2}, {"a": 0, "b": 0}]
+    params = [
+        {"data_split": _split([0.6, 0.7, 0.8], [0.1, 0.2, 0.3], [0.3, 0.2, 0.4])},
+        {"data_split": _split([0.0, 0.1, -0.1], [0.0, 0.1, -0.1], [0.0, -0.2, 0.1])},
+    ]
 
     val_engine = ValidationEngine()
     val_results = val_engine.run(params)
-    assert val_results[0]["score"] == 3
     assert "in_sample" in val_results[0]["tests"]
+    assert val_results[0]["results"]["out_of_sample"]["metric"] == pytest.approx(0.3)
+    assert val_results[0]["score"] > val_results[1]["score"]
 
     analytics = AnalyticsEngine(max_size=1)
     analytics.ingest(val_results)
     winners = analytics.get_winners()
-    assert winners[0]["params"] == {"a": 1, "b": 2}
+    assert winners[0]["params"]["data_split"] == params[0]["data_split"]
 
     pkg_engine = PackagingEngine()
     pkg_result = pkg_engine.package("strat", winners)

--- a/tests/test_validation_engine.py
+++ b/tests/test_validation_engine.py
@@ -1,0 +1,81 @@
+import pytest
+import pandas as pd
+from data.data_structures import DataSplit
+
+from validation import ValidationEngine, ValidationConfig, ValidationTestConfig
+
+
+def _make_split(optimize, validate, test):
+    optimize_df = pd.DataFrame({"returns": optimize})
+    validate_df = pd.DataFrame({"returns": validate})
+    test_df = pd.DataFrame({"returns": test})
+    return DataSplit(train=optimize_df, validation=validate_df, test=test_df, metadata={})
+
+
+def test_validation_engine_runs_all_tests():
+    config = ValidationConfig(
+        in_sample=ValidationTestConfig(params={"threshold": 0.1}),
+        out_of_sample=ValidationTestConfig(params={"threshold": 0.2}),
+        in_sample_permutation=ValidationTestConfig(
+            enabled=True, params={"permutations": 10, "threshold": 1.0}
+        ),
+        out_of_sample_permutation=ValidationTestConfig(
+            enabled=True, params={"permutations": 10, "threshold": 1.0}
+        ),
+        noise_injection=ValidationTestConfig(
+            enabled=True, params={"simulations": 10, "sigma": 0.01}
+        ),
+        monte_carlo=ValidationTestConfig(
+            enabled=True, params={"simulations": 10}
+        ),
+        regime_testing=ValidationTestConfig(enabled=True),
+    )
+
+    split = _make_split([0.6, 0.7, 0.8], [0.1, 0.2, 0.3], [0.3, 0.4, 0.5])
+
+    engine = ValidationEngine(config=config, max_workers=1)
+    params = [{"data_split": split}]
+
+    results = engine.run(params)
+    assert len(results) == 1
+    res = results[0]
+    expected_tests = {
+        "in_sample",
+        "out_of_sample",
+        "in_sample_permutation",
+        "out_of_sample_permutation",
+        "noise_injection",
+        "monte_carlo",
+        "regime_testing",
+    }
+    assert set(res["tests"]) == expected_tests
+    assert set(res["results"].keys()) == expected_tests
+    assert res["passed"] is True
+    assert res["results"]["in_sample"]["metric"] == pytest.approx(0.2)
+    assert res["results"]["out_of_sample"]["metric"] == pytest.approx(0.4)
+    # Score is sum of individual metrics
+    metric_sum = sum(v["metric"] for v in res["results"].values())
+    assert res["score"] == pytest.approx(metric_sum)
+    assert res["runtime"] >= 0
+
+
+def test_validation_engine_uses_data_split():
+    optimize = [0.6, 0.7, 0.8]
+    validate = [0.1, 0.2, 0.3]
+    test = [0.3, 0.4, 0.5]
+    split = _make_split(optimize, validate, test)
+
+    engine = ValidationEngine()
+    params = [
+        {
+            "data_split": split,
+            "in_sample_returns": [999],
+            "out_of_sample_returns": [-999],
+        }
+    ]
+    res = engine.run(params)[0]
+
+    assert res["results"]["in_sample"]["metric"] == pytest.approx(sum(validate) / len(validate))
+    assert res["results"]["out_of_sample"]["metric"] == pytest.approx(sum(test) / len(test))
+    assert res["runtime"] >= 0
+


### PR DESCRIPTION
## Summary
- remove optimization aliases from `DataSplit`
- derive in-sample returns from the validation split and out-of-sample from the test split
- update validation tests for the new split usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afee4787c883309b61994a37a933e9