### PR TITLE
Enhance validation split handling and analytics caching

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/analytics/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/analytics/__init__.py
@@ -2,16 +2,25 @@ from typing import Any, Dict, List
 
 
 class AnalyticsEngine:
-    """Cache validation results and return the best performers."""
+    """Cache validation results and return the best performers.
+
+    Only parameter sets that pass their validation tests are cached.  This
+    mirrors production behaviour where failed strategies are discarded rather
+    than forwarded to downstream analytics or packaging stages.
+    """
 
     def __init__(self, max_size: int = 10) -> None:
         self.max_size = max_size
         self._cache: List[Dict[str, Any]] = []
 
     def ingest(self, validation_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Store results and keep only the highest scoring entries."""
+        """Store results and keep only the highest scoring entries.
 
-        self._cache.extend(validation_results)
+        Only results with ``passed=True`` are considered for caching.
+        """
+
+        passed = [r for r in validation_results if r.get("passed")]
+        self._cache.extend(passed)
         self._cache.sort(key=lambda r: r.get("score", 0), reverse=True)
         self._cache = self._cache[: self.max_size]
         return self._cache


### PR DESCRIPTION
## Summary
- Support train+validation splits in the validation engine by concatenating provided in-sample components
- Cache only passing results in AnalyticsEngine and document behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b006e8d23483309f2d5728bc0a9bbe