### PR TITLE
Add analytics tear sheets and relax informational tests

### DIFF
--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/analytics/__init__.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/analytics/__init__.py
@@ -1,20 +1,73 @@
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
 from typing import Any, Dict, List
+
+import pandas as pd
+from quantstats import reports as qsr
+from quantstats import stats as qs
 
 
 class AnalyticsEngine:
-    """Cache validation results and return the best performers."""
+    """Augment validation results with quantstats tear sheets and select winners."""
 
-    def __init__(self, max_size: int = 10) -> None:
+    def __init__(self, max_size: int = 10, output_dir: str | os.PathLike[str] = "tear_sheets") -> None:
         self.max_size = max_size
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
         self._cache: List[Dict[str, Any]] = []
 
-    def ingest(self, validation_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Store results and keep only the highest scoring entries."""
+    def _generate_tear_sheet(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Create quantstats tear sheet and compute key metrics."""
 
-        self._cache.extend(validation_results)
+        params = result.get("params", {})
+        returns = (
+            params.get("in_sample_returns", [])
+            + params.get("out_of_sample_returns", [])
+        )
+
+        if not returns:
+            return {}
+
+        index = pd.date_range("2000-01-01", periods=len(returns), freq="D")
+        series = pd.Series(returns, index=index)
+
+        def _safe(metric_fn: callable) -> float:
+            try:
+                value = metric_fn(series)
+                return float(value) if value is not None else float("nan")
+            except Exception:
+                return float("nan")
+
+        metrics = {
+            "sharpe": _safe(qs.sharpe),
+            "sortino": _safe(qs.sortino),
+            "calmar": _safe(qs.calmar),
+            "max_drawdown": _safe(qs.max_drawdown),
+        }
+
+        file_path = self.output_dir / f"tear_sheet_{uuid.uuid4().hex}.html"
+        try:
+            qsr.html(series, output=str(file_path), title="Strategy Tear Sheet")
+        except Exception:
+            file_path = Path()
+
+        return {"metrics": metrics, "path": str(file_path)}
+
+    def ingest(self, validation_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Store passed results, attach tear sheets, and keep top performers."""
+
+        for res in validation_results:
+            if not res.get("passed"):
+                continue
+            res["tear_sheet"] = self._generate_tear_sheet(res)
+            self._cache.append(res)
+
         self._cache.sort(key=lambda r: r.get("score", 0), reverse=True)
         self._cache = self._cache[: self.max_size]
-        return self._cache
+        return list(self._cache)
 
     def get_winners(self, top_n: int | None = None) -> List[Dict[str, Any]]:
         """Return cached winners, optionally limited to *top_n* entries."""
@@ -22,3 +75,4 @@ class AnalyticsEngine:
         if top_n is None or top_n >= len(self._cache):
             return list(self._cache)
         return self._cache[:top_n]
+

--- a/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/engine.py
+++ b/TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY/validation/engine.py
@@ -27,6 +27,8 @@ class ValidationEngine:
         total_score = 0.0
         passed_all = True
 
+        informational = {"noise_injection", "regime_testing"}
+
         for name, cfg in self.config.__dict__.items():
             if not isinstance(cfg, ValidationTestConfig) or not cfg.enabled:
                 continue
@@ -35,8 +37,10 @@ class ValidationEngine:
             metric, passed = test_fn(params, rng=rng, **cfg.params)
             results[name] = {"metric": metric, "passed": passed}
             executed.append(name)
-            total_score += metric
-            passed_all = passed_all and passed
+
+            if name not in informational:
+                total_score += metric
+                passed_all = passed_all and passed
 
         return {
             "params": params,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ psycopg2-binary
 scikit-learn
 scipy
 torch
+quantstats
+ipython
+psutil

--- a/tests/test_validation_analytics_packaging.py
+++ b/tests/test_validation_analytics_packaging.py
@@ -1,9 +1,11 @@
+import os
+
 from validation import ValidationEngine
 from analytics import AnalyticsEngine
 from packager import PackagingEngine
 
 
-def test_validation_analytics_packaging_flow():
+def test_validation_analytics_packaging_flow(tmp_path):
     params = [
         {
             "in_sample_returns": [0.6, 0.7, 0.8],
@@ -20,12 +22,19 @@ def test_validation_analytics_packaging_flow():
     assert "in_sample" in val_results[0]["tests"]
     assert val_results[0]["score"] > val_results[1]["score"]
 
-    analytics = AnalyticsEngine(max_size=1)
+    analytics = AnalyticsEngine(max_size=1, output_dir=tmp_path)
     analytics.ingest(val_results)
     winners = analytics.get_winners()
+    assert len(winners) == 1
     assert winners[0]["params"] == params[0]
+    ts = winners[0]["tear_sheet"]
+    assert "metrics" in ts and "path" in ts
+    assert "sharpe" in ts["metrics"]
+    assert os.path.exists(ts["path"]) if ts["path"] else True
 
     pkg_engine = PackagingEngine()
     pkg_result = pkg_engine.package("strat", winners)
     assert pkg_result["success"]
-    assert pkg_result["packages"][0]["package_name"] == "strat_1.zip"
+    pkg = pkg_result["packages"][0]
+    assert pkg["package_name"] == "strat_1.zip"
+    assert "metrics" in pkg["tear_sheet"]


### PR DESCRIPTION
## Summary
- generate quantstats HTML tear sheets and metrics for strategies that pass validation
- treat noise injection and regime testing as informational for scoring
- verify packaging flow includes tear sheet paths
- declare psutil runtime dependency

## Testing
- `python 'TopStepB - MAIN CLEAN - BEFORE SECOND STRATEGY'/main_runner.py --strategy bollinger_squeeze --symbol ES --timeframe 5m --account-type topstep_50k --slippage 0.5 --commission 2.5 --contracts-per-trade 1 --split-type chronological --synthetic-bars 10000 --max-trials 20 --validation-tests all`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f800ab7c8330906f160e49cf3117